### PR TITLE
sensitive info should not require file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Special files that should not be sent to Github
 config.json
-ubuntuStation/database.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/ubuntuStation/database.py
+++ b/ubuntuStation/database.py
@@ -4,7 +4,7 @@ import json
 
 with open('config.json') as json_data_file:
     data=json.load(json_data_file)
-url = 'postgresql://' + data["user"] + ":" + data["pass"] + "@localhost" + ":" + data["port"] + "/" + "dbname"
+url = 'postgresql://' + data["user"] + ":" + data["pass"] + "@localhost" + ":" + data["port"] + "/" + data["dbname"]
 
 engine=create_engine(url)
 db_session=scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))

--- a/ubuntuStation/database.py
+++ b/ubuntuStation/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+import json
+
+with open('config.json') as json_data_file:
+    data=json.load(json_data_file)
+url = 'postgresql://' + data["user"] + ":" + data["pass"] + "@localhost" + ":" + data["port"] + "/" + "dbname"
+
+engine=create_engine(url)
+db_session=scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))


### PR DESCRIPTION
Sensitive info pertaining to the database was previously kept in database.py.  However due to config.json already containing sensitive info, the contents from database.py was moved to config.json such that now we would only need to maintain a single file for sensitive information.