### PR TITLE
#7 sensitive info moved to config.json

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Special files that should not be sent to Github
 config.json
-ubuntuStation/database.py
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/ubuntuStation/database.py
+++ b/ubuntuStation/database.py
@@ -1,0 +1,10 @@
+from sqlalchemy import create_engine
+from sqlalchemy.orm import scoped_session, sessionmaker
+import json
+
+with open('config.json') as json_data_file:
+    data=json.load(json_data_file)
+url = 'postgresql://' + data["user"] + ":" + data["pass"] + "@localhost" + ":" + data["port"] + "/" + data["dbname"]
+
+engine=create_engine(url)
+db_session=scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))


### PR DESCRIPTION
In response to this [PR](https://github.com/erdl/survey_admin/pull/28). Squashed down to a single commit. The change in gitignore is implied so didn't bother to keep that separate. If you want it as two commits lmk, easy change. 