### PR TITLE
implement edit survey questions

### DIFF
--- a/survey_admin/forms.py
+++ b/survey_admin/forms.py
@@ -1,6 +1,6 @@
 from flask_wtf import FlaskForm
 from .models import *
-from wtforms import SelectField, IntegerField, BooleanField, RadioField, TextField, TextAreaField, SelectMultipleField, PasswordField, FieldList, FormField
+from wtforms import SelectField, IntegerField, BooleanField, RadioField, TextField, TextAreaField, SelectMultipleField, PasswordField, FieldList, FormField, widgets
 from wtforms.validators import DataRequired, ValidationError
 
 class UniqueValidator(object):
@@ -88,3 +88,29 @@ class EditDeploymentForm(FlaskForm):
 class LoginForm(FlaskForm):
     username=TextField('username', description=u'Username', validators=[DataRequired()])
     password=PasswordField('password', description=u'Password', validators=[DataRequired()])
+
+class MultiCheckboxField(SelectMultipleField):
+    """
+    A multiple-select, except displays a list of checkboxes.
+
+    Iterating the field will produce subfields, allowing custom rendering of
+    the enclosed checkbox fields.
+    """
+    widget = widgets.ListWidget(prefix_label=False)
+    option_widget = widgets.CheckboxInput()
+
+class EditSurveyForm(FlaskForm):
+    survey_questions = MultiCheckboxField()
+
+    # check to make sure that at least one question has been selected for the survey
+    # this is a custom validation that gets called when we call form.validate_on_submit()
+    def validate(self):
+        is_correctly_filled = bool(len([question.data for question in self.survey_questions if question.checked]))
+
+        if is_correctly_filled:
+            return True
+        else:
+            self.errors['survey_questions'] = 'At least one question must be selected for a survey'
+            return False
+
+

--- a/survey_admin/static/stylesheets/edit_survey_form.css
+++ b/survey_admin/static/stylesheets/edit_survey_form.css
@@ -1,0 +1,12 @@
+#check-questions-field {
+    background-color: white;
+    height: auto;
+    width: 50%;
+}
+
+#form-description-box {
+    margin-left: 0;
+    margin-right: 0;
+    height: auto;
+    width: 50%;
+}

--- a/survey_admin/templates/edit_survey_form.html
+++ b/survey_admin/templates/edit_survey_form.html
@@ -1,0 +1,52 @@
+{% extends 'base.html' %}
+
+{% block head %}
+    {{ super() }}
+    <link rel="stylesheet" type="text/css" href="/static/stylesheets/edit_survey_form.css">
+{% endblock %}
+
+{% block content %}
+<div class="well">
+
+    <h1>Edit Survey</h1>
+    <div class="container" id="form-description-box">
+        <p class="text-muted">Use this form to edit an existing survey.</p>
+        <p class="text-dark">
+            <a class="text-danger">Red questions</a> denote survey questions that are already set for this survey. Altering
+            an existing survey should be done with caution as this affects the surveys results when viewed over a period of time.
+            Once a survey is deployed and we are receiving data from that survey, the questions it contains should not be changed.
+        </p>
+    </div>
+
+    <div class="container">
+        <form action="{{ url_for('edit_survey_form', survey_info_id=survey_info_id) }}" method='POST' name='edit_survey_form'>
+            {{ form.csrf_token }}
+            <div class="form-group" id="check-questions-field">
+                {{ form.survey_questions }}
+            </div>
+
+            <button type="submit" name="action" class="btn btn-primary" value="Submit">Submit</button>
+        </form>
+        <p class="text-danger">{{ form.errors['survey_questions'] }}</p>
+    </div>
+
+
+</div>
+
+<script>
+    // whatever questions are currently selected are checked and colored red so that
+    // the user knows what was previously used instead of just having a blank form
+    var currently_selected_questions = '{{ currently_selected_questions }}'.split(',');
+    console.log(currently_selected_questions);
+
+    $('#survey_questions > li').each(function(i) {
+        var input = $('#survey_questions-' + i);
+        var label = $('label[for=survey_questions-' + i);
+        if (currently_selected_questions.includes(input.attr('value'))) {
+            input.attr('checked', 'true');
+            label.css('color', 'red');
+        }
+    });
+</script>
+
+{% endblock %}

--- a/survey_admin/templates/questionpage.html
+++ b/survey_admin/templates/questionpage.html
@@ -3,7 +3,7 @@
 	<div class="container">
 		<h1>{{ question.question_description }}</h1>
 		<h3>Question Text</h3>
-		<p>{{ question.question_text }}</p>
+		<p>{{ question.question_text | safe }}</p>
 		<h3>Options</h3>
 			<ul>	
 				{% for o in option %}

--- a/survey_admin/templates/show_questions.html
+++ b/survey_admin/templates/show_questions.html
@@ -18,7 +18,7 @@
 	{% for question in questions %}
 		<tr>
 			<td><a href="{{ url_for('question_page', questionid=question.question_id) }}">{{ question.question_description }}</a></td>
-			<td>{{ question.question_text }}</td>
+			<td>{{ question.question_id }} {{ question.question_text | safe }}</td>
 		</tr>
 	{% endfor %}
 	</table>

--- a/survey_admin/templates/show_surveys.html
+++ b/survey_admin/templates/show_surveys.html
@@ -19,6 +19,8 @@
 		<tr>
 			<td><a href="{{ url_for('survey_page', surveyid=s.survey_info_id) }}">{{ s.survey_name }}</a></td>
 			<td>{{ s.description }}</td>
+
+            <td><a href="{{ url_for('edit_survey_form', survey_info_id=s.survey_info_id) }}" class="btn btn-warning btn-sm">Edit</a></td>
 		</tr>
 	{% endfor %}
 	</table>

--- a/survey_admin/templates/surveypage.html
+++ b/survey_admin/templates/surveypage.html
@@ -17,7 +17,7 @@
 		<h1>Questions</h1>
 			<ul>
 				{% for question in questions %}
-				<li><a href={{ url_for('question_page', questionid = question.question_id) }}>{{ question.question_description }}</a><p class="text-muted">{{ question.question_text }}</p></li>
+				<li><a href={{ url_for('question_page', questionid = question.question_id) }}>{{ question.question_description }}</a><p class="text-muted">{{ question.question_text | safe }}</p></li>
 				{% endfor %}	
 			</ul>
 		<h1>Active On These URLs</h1>

--- a/survey_admin/views.py
+++ b/survey_admin/views.py
@@ -88,17 +88,18 @@ def callback():
             user_data = resp.json()
             email = user_data['email']
             user = User.query.filter_by(email=email).first()
+
             if user is None:
-                #user = User()
-                #user.email = email
+                # the user does not exist in our database, therefore someone tried to login
+                # that hasn't been authorized to do so. redirect them to the 'login' page..
                 return redirect(url_for('login'))
-            user.name = user_data['name']
-            print(token)
+
             user.tokens = json.dumps(token)
             db.session.add(user)
             db.session.commit()
             login_user(user)
             return redirect(url_for('home'))
+
         return 'Could not fetch your information.'
 
 @app.route('/logout')


### PR DESCRIPTION
An edit survey form has been implemented. There are warnings on the form to inform the user what happens when questions for  existing surveys are changed.  It's made very clear to the user what questions are currently in use by the survey so that they are sure of what they are changing. 

Also, any inner html inside of questions are now rendered. This was a small aesthetic change to make it clear to the user what the question will look like when someone views the survey on a tablet or the computer. 

